### PR TITLE
Adds a mirror mode for keeping a local directory in sync with the latest nexus state

### DIFF
--- a/nexus3_exporter.py
+++ b/nexus3_exporter.py
@@ -101,6 +101,8 @@ def download_assets(quiet, auth, output_dir, no_verify, asset_listing):
     with tqdm(asset_listing, leave=not quiet) as pbar:
         for asset in pbar:
             file_path = os.path.join(output_dir, asset["path"])
+            relative_path = asset["path"].lstrip("/")
+            file_path = os.path.join(output_dir, relative_path)
             error = download_single_asset(quiet, auth, file_path, no_verify, asset)
 
             if error:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests
-tqdm
+requests~=2.32.4
+tqdm~=4.67.1
+urllib3~=2.5.0


### PR DESCRIPTION
Added this for using a shared volume with [Chained Local Repository Manager (CLRM)](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=235837219) instead of using http calls to an external nexus.